### PR TITLE
scipy>=1.5.0 required for scipy.linalg.eigh subset_by_index keyword usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scipy>=1.4.1
+scipy>=1.5.0
 matplotlib>=3.2.2
 opencv-python>=4.1.2
 tqdm>=4.41.0


### PR DESCRIPTION
`subset_by_index` is used [here](https://github.com/YangtaoWANG95/TokenCut/blob/095cae81b305c3c6faac54de567c7a471477599d/object_discovery.py#L38) but [it was only introduced in scipy 1.5.0](https://docs.scipy.org/doc/scipy/release.1.5.0.html#scipy-linalg-improvements)