### PR TITLE
fix url for DINO model download

### DIFF
--- a/unsupervised_saliency_detection/dino.py
+++ b/unsupervised_saliency_detection/dino.py
@@ -304,7 +304,7 @@ class ViTFeat(nn.Module):
         self.patch_size = patch_size
 
 #        state_dict = torch.load(pretrained_pth, map_location="cpu")
-        state_dict = torch.hub.load_state_dict_from_url(pretrained_pth)
+        state_dict = torch.hub.load_state_dict_from_url("https://dl.fbaipublicfiles.com"+pretrained_pth)
         self.model.load_state_dict(state_dict, strict=True)
         print('Loading weight from {}'.format(pretrained_pth))
 


### PR DESCRIPTION
Hi,
I've created this PR to fix the `url` for DINO model download in line 307 of `unsupervised_saliency_detection/dino.py`. The actual url should be: `"https://dl.fbaipublicfiles.com"+pretrained_pth`, using just `pretrained_pth` throws an error.

Thanks.